### PR TITLE
Load password-lifetime setting from dotenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,22 @@ Route::middleware(['auth', 'password_changed'])->group(function () {
 });
 ```
 
-## Disable in some environment.
+## Translations.
+You may translate the package string messages (defined in config `lara-pass.messages`) adding the translated strings in `lang/<locale>.json` files.
+
+## Environment settings.
 If you want to disable Password Policy on specific environment (ex: `local`) set to `false` this variable in `.env` file:
 
 ```ini
 # Set to false to disable password policy.
 PASSWORD_POLICY_ENABLED=false
+```
+
+You may also customize the number of days before the passwords expire setting the variable in `.env` file:
+
+```ini
+# Set to false to disable password policy.
+PASSWORD_LIFETIME=30
 ```
 
 ## Validation rules.

--- a/config/lara-pass-policy.php
+++ b/config/lara-pass-policy.php
@@ -48,11 +48,11 @@ return [
     |--------------------------------------------------------------------------
     |
     | This configuration is used to notify user if the password used
-    | is expired and need to change the password
+    | is expired and need to change the password.
     |
     */
 
-    'password_lifetime' => 60, //days
+    'password_lifetime' => env('PASSWORD_LIFETIME', 30), // days
 
     'reminder_password_to_change' => [
         1, // last 1 days


### PR DESCRIPTION
This PR add the possibility to override the `password_lifetime` (default 30 days) loading the value from `.env` file.